### PR TITLE
chore: Deps upgrade

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/losfair/sqlite-cache"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rusqlite = { version = "0.27", features = ["bundled"] }
+rusqlite = { version = "0.30", features = ["bundled"] }
 data-encoding = "2.5.0"
 futures = "0.3.29"
 tracing = "0.1.40"
@@ -19,7 +19,7 @@ tracing = "0.1.40"
 tracing-test = "0.2.4"
 tokio = { version = "1.35.0", features = ["macros", "rt", "time"] }
 rand = "0.8"
-criterion = "0.3"
+criterion = "0.5"
 
 [[bench]]
 name = "cache_benchmark"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,14 +10,14 @@ repository = "https://github.com/losfair/sqlite-cache"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rusqlite = "0.27"
-data-encoding = "2.3.2"
-futures = "0.3.21"
-tracing = "0.1.35"
+rusqlite = { version = "0.27", features = ["bundled"] }
+data-encoding = "2.5.0"
+futures = "0.3.29"
+tracing = "0.1.40"
 
 [dev-dependencies]
-tracing-test = "0.2.2"
-tokio = { version = "1.19.2", features = ["macros", "rt", "time"] }
+tracing-test = "0.2.4"
+tokio = { version = "1.35.0", features = ["macros", "rt", "time"] }
 rand = "0.8"
 criterion = "0.3"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/losfair/sqlite-cache"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rusqlite = { version = "0.30", features = ["bundled"] }
+rusqlite = { version = "0.30" }
 data-encoding = "2.5.0"
 futures = "0.3.29"
 tracing = "0.1.40"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,10 +80,7 @@ impl Cache {
     }
 
     fn flush(&self) {
-        let lazy_expiry_update = std::mem::replace(
-            &mut *self.inner.lazy_expiry_update.lock().unwrap(),
-            HashMap::new(),
-        );
+        let lazy_expiry_update = std::mem::take(&mut *self.inner.lazy_expiry_update.lock().unwrap());
         for ((table_name, key), expiry) in lazy_expiry_update {
             let res = self.inner.conn.lock().unwrap().execute(
                 &format!("update {} set expiry = ? where k = ?", table_name),


### PR DESCRIPTION
- bundles `rusqlite`: it is statically linked. Solves the version mismatch problem. __This may be a bad idea__.  The official documentation note about this 
```
- [dependencies]
# `bundled` causes us to automatically compile and link in an up to date
# version of SQLite for you. This avoids many common build issues, and
# avoids depending on the version of SQLite on the users system (or your
# system), which may be old or missing. It's the right choice for most
# programs that control their own SQLite databases.
#
# That said, it's not ideal for all scenarios and in particular, generic
# libraries built around `rusqlite` should probably not enable it, which
# is why it is not a default feature -- it could become hard to disable.
rusqlite = { version = "0.30.0", features = ["bundled"] }
```
## benchmark numbers on Windows 11 machine. `1th Gen Intel(R) Core(TM) i7-11370H @ 3.30GHz 3.30 GHz`

```bash
lookup - cache size 10000
                        time:   [3.0272 µs 3.0754 µs 3.1286 µs]
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe

lookup mt(4) - cache size 10000
                        time:   [22.358 µs 24.601 µs 26.954 µs]
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) high mild
  3 (3.00%) high severe

insert - cache size 10000
                        time:   [12.359 µs 12.730 µs 13.152 µs]
Found 11 outliers among 100 measurements (11.00%)
  6 (6.00%) high mild
  5 (5.00%) high severe

insert mt(4) - cache size 10000
                        time:   [70.530 µs 78.182 µs 86.341 µs]
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) high mild
  3 (3.00%) high severe
```